### PR TITLE
Constructing color codes using snprintf for memory safety

### DIFF
--- a/SDAppDelegate.m
+++ b/SDAppDelegate.m
@@ -596,9 +596,10 @@ static NSColor* SDColorFromHex(NSString* hex) {
 }
 
 static char* HexFromSDColor(NSColor* color) {
-    char* buffer = (char*) malloc(6 * sizeof(char));
+    size_t bufferSize = 6;
+    char* buffer = (char*) malloc(bufferSize * sizeof(char));
     NSColor* c = [color colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
-    sprintf(buffer, "%2X%2X%2X",
+    snprintf(buffer, bufferSize, "%2X%2X%2X",
             (unsigned int) ([c redComponent] * 255.99999),
             (unsigned int) ([c greenComponent] * 255.99999),
             (unsigned int) ([c blueComponent] * 255.99999));


### PR DESCRIPTION
_Summary: Running the `choose` binary terminates in a SIGILL (illegal instruction). I'm hoping this change keeps that from happening!_

I originally experienced this when looking at https://github.com/Homebrew/homebrew-core/pull/59669. I have some more notes on how I arrived at this point, if anyone is interested. But I'll leave out the boring details, and stick to the relevant points. I'd be happy to answer any questions if I can!

### Reproducing the error

These are the steps I took on the default branch. When I do them with applied changes, I see the expected output.

1. Build from source:
   ```
   > xcodebuild SDKROOT= SYMROOT=build clean
   > xcodebuild SDKROOT= SYMROOT=build -configuration Release build
   ```

2. Run the executable. Actual output:
   ```
   # Bash
   $ /usr/local/Cellar/choose-gui/1.2/bin/choose -h
   Illegal instruction: 4

    # Zsh
    % /usr/local/Cellar/choose-gui/1.2/bin/choose -h
    zsh: illegal hardware instruction  /usr/local/Cellar/choose-gui/1.2/bin/choose -h

    # fish
    > /usr/local/Cellar/choose-gui/1.2/bin/choose -h
    fish: '/usr/local/Cellar/choose-gui/1.…' terminated by signal SIGILL (Illegal instruction)
    ```

3. Expected output:
   ```
   > build/Release/choose -h
   usage: build/Release/choose
   --snip--
   ```

### System Software Overview

Versions:
* System: macOS 10.15.6 (19G2021)
* Kernel: Darwin 19.6.0
* Xcode: Version 11.7 (11E801a)
