### PR TITLE
Allow wraparound on up/down arrow

### DIFF
--- a/SDAppDelegate.m
+++ b/SDAppDelegate.m
@@ -526,12 +526,22 @@ static BOOL SDReturnStringOnMismatch;
         return YES;
     }
     else if (commandSelector == @selector(moveUp:)) {
-        self.choice = MAX(self.choice - 1, 0);
+        if (self.choice <= 0) {
+            self.choice = [self.filteredSortedChoices count] - 1;
+        } else {
+            self.choice -= 1;
+        }
+        
         [self reflectChoice];
         return YES;
     }
     else if (commandSelector == @selector(moveDown:)) {
-        self.choice = MIN(self.choice + 1, [self.filteredSortedChoices count]-1);
+        if (self.choice >= [self.filteredSortedChoices count] - 1) {
+            self.choice = 0;
+        } else {
+            self.choice += 1;
+        }
+        
         [self reflectChoice];
         return YES;
     }


### PR DESCRIPTION
I found myself wanting to filter a `choose` selection a little, then select the last entry in the list. This change allows the up/down arrows to "wrap" around, so:

- Pressing up with the first item selected moves the selection to the last item, and
- Pressing down with the last item selected moves the selection to the first item

Screen recording to demonstrate:

https://user-images.githubusercontent.com/760143/111251757-f4178b00-8663-11eb-8095-9f3eb473a38c.mov