### PR TITLE
Explicitly set xcodebuild configuration to Release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ uninstall-docs: ## Uninstall documentation
 
 $(APPFILE): SDAppDelegate.m choose.xcodeproj
 	rm -rf $@
-	xcodebuild clean build > /dev/null
+	xcodebuild -configuration Release clean build > /dev/null
 	cp -R build/Release/choose $@
 
 $(TGZFILE): $(APPFILE)


### PR DESCRIPTION
If option `-configuration` is omitted `Debug` value will be used by default and binary will be outputed to `build/Debug/choose` instead of `build/Release/choose`. I faced this issue while building `choose` using Xcode 13.0