### PR TITLE
Installation command has no prompt sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Install
 
 ```bash
-$ brew install choose-gui
+brew install choose-gui
 ```
 
 ### Build and Install Documentation


### PR DESCRIPTION
It's easier to copy and use without prompt. 