### PR TITLE
Add window title

### DIFF
--- a/SDAppDelegate.m
+++ b/SDAppDelegate.m
@@ -226,13 +226,14 @@ static BOOL SDReturnStringOnMismatch;
 - (void) setupWindow:(NSRect)winRect {
     BOOL usingYosemite = (NSClassFromString(@"NSVisualEffectView") != nil);
 
-    NSUInteger styleMask = usingYosemite ? (NSFullSizeContentViewWindowMask | NSTitledWindowMask) : NSBorderlessWindowMask;
+    NSUInteger styleMask = usingYosemite ? (NSFullSizeContentViewWindowMask | NSTitledWindowMask) : NSWindowStyleMaskBorderless;
     self.window = [[SDMainWindow alloc] initWithContentRect: winRect
                                                   styleMask: styleMask
                                                     backing: NSBackingStoreBuffered
                                                       defer: NO];
 
     [self.window setDelegate: self];
+    [self.window setTitle:@"choose"];
 
     if (usingYosemite) {
         self.window.titlebarAppearsTransparent = YES;
@@ -531,7 +532,7 @@ static BOOL SDReturnStringOnMismatch;
         } else {
             self.choice -= 1;
         }
-        
+
         [self reflectChoice];
         return YES;
     }
@@ -541,7 +542,7 @@ static BOOL SDReturnStringOnMismatch;
         } else {
             self.choice += 1;
         }
-        
+
         [self reflectChoice];
         return YES;
     }


### PR DESCRIPTION
For window managers like Amethyst, the bundle id doesn't work, and the other identifier is a window title. This just adds a title to the window so it is easier to identify by applications.

I don't mind if you don't merge this, but I just thought to open a pull request. Amazing app you guys have developed, by the way. Extremely useful.