### PR TITLE
Add usage example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,17 @@ manual page.
 
 ## Usage
 
+### List the content from current directory
+
 ```bash
 $ ls | choose
+```
+
+### Open apps from the applications directories
+
+```bash
+$ ls /Applications/ /Applications/Utilities/ /System/Applications/ /System/Applications/Utilities/ | \
+$ grep '\.app$' | sed 's/\.app$//g' | choose | xargs -I {} open -a "{}.app"
 ```
 
 ## License


### PR DESCRIPTION
Added an usage example to the README.
This example is a command that:
1. Gets all apps from the macOS default applications directories.
2. Lists the apps, removing the '.app' extention, in choose.
3. Outputs the matched app name in choose to 'xargs'.
4. Runs the selected app with the 'open' command.