### PR TITLE
Implement password mode

### DIFF
--- a/SDAppDelegate.m
+++ b/SDAppDelegate.m
@@ -22,6 +22,7 @@ static BOOL VisualizeWhitespaceCharacters;
 static BOOL AllowEmptyInput;
 static BOOL MatchFromBeginning;
 static BOOL ScoreFirstMatchedPosition;
+static BOOL Password;
 
 static NSString* LastQueryString;
 static int LastCursorPos;
@@ -341,7 +342,7 @@ static NSString* ScriptAtList;
 //    [icon setImageFrameStyle: NSImageFrameButton];
     [[self.window contentView] addSubview: icon];
 
-    self.queryField = [[NSTextField alloc] initWithFrame: textRect];
+    self.queryField = Password ? [[NSSecureTextField alloc] initWithFrame: textRect] : [[NSTextField alloc] initWithFrame: textRect];
     [self.queryField setAutoresizingMask: NSViewWidthSizable | NSViewMinYMargin ];
     [self.queryField setDelegate: self];
     [self.queryField setStringValue: InitialQuery];
@@ -789,7 +790,7 @@ static NSString* Script(NSString* pathToScript, NSString* queryInput, NSString* 
 #else
 
     NSFileHandle* stdinHandle = [NSFileHandle fileHandleWithStandardInput];
-    NSData* inputData = [stdinHandle readDataToEndOfFile];
+    NSData* inputData = Password ? nil : [stdinHandle readDataToEndOfFile];
     NSString* inputStrings = [[[NSString alloc] initWithData:inputData encoding:NSUTF8StringEncoding] stringByTrimmingCharactersInSet: [NSCharacterSet whitespaceAndNewlineCharacterSet]];
 
     if ([inputStrings length] == 0 && !AllowEmptyInput)
@@ -829,6 +830,7 @@ static void usage(const char* name) {
     printf(" -u           disable underline and use background for matched string\n");
     printf(" -m           return the query string in case it doesn't match any item\n");
     printf(" -p           defines a prompt to be displayed when query field is empty\n");
+    printf(" -P           conceals keyboard input / password mode (implies -m, -e and -n 0)\n");
     printf(" -q           defines initial query to start with (empty by default)\n");
     printf(" -r           path to a script to run when typing. Output appended to input field. Two args provided upon run:\n");
     printf("               - the query text from input field\n");
@@ -876,13 +878,14 @@ int main(int argc, const char * argv[]) {
         SDNumRows = 10;
         SDReturnStringOnMismatch = NO;
         SDPercentWidth = -1;
+        Password = NO;
 
         static SDAppDelegate* delegate;
         delegate = [[SDAppDelegate alloc] init];
         [NSApp setDelegate: delegate];
 
         int ch;
-        while ((ch = getopt(argc, (char**)argv, "lvyezaf:s:r:c:b:n:w:p:q:r:t:x:o:hium")) != -1) {
+        while ((ch = getopt(argc, (char**)argv, "lvyezaf:s:r:c:b:n:w:p:q:r:t:x:o:Phium")) != -1) {
             switch (ch) {
                 case 'i': SDReturnsIndex = YES; break;
                 case 'f': queryFontName = optarg; break;
@@ -895,6 +898,7 @@ int main(int argc, const char * argv[]) {
                 case 'u': SDUnderlineDisabled = YES; break;
                 case 'm': SDReturnStringOnMismatch = YES; break;
                 case 'p': queryPromptString = optarg; break;
+                case 'P': Password = YES; AllowEmptyInput = YES; SDReturnStringOnMismatch = YES; SDNumRows = 0; break;
                 case 'q': InitialQuery = [NSString stringWithUTF8String: optarg]; break;
                 case 'r': ScriptAtInput = [NSString stringWithUTF8String: optarg]; break;
                 case 't': ScriptAtList = [NSString stringWithUTF8String: optarg]; break;


### PR DESCRIPTION
This implements password mode as described in #59.

It automatically uses sensible settings by discarding input, allowing empty input, returning string on mismatch and setting display rows to 0.

To test:

```shell
./choose -P < /dev/null
```

Closes #59.