### PR TITLE
More matching and sorting options, a couple usability improvements

### DIFF
--- a/SDAppDelegate.m
+++ b/SDAppDelegate.m
@@ -942,7 +942,7 @@ static NSString* Script(NSString* pathToScript, NSString* queryInput, NSString* 
 #else
 
     NSFileHandle* stdinHandle = [NSFileHandle fileHandleWithStandardInput];
-    NSData* inputData = [stdinHandle readDataToEndOfFile];
+    NSData* inputData = Password ? nil : [stdinHandle readDataToEndOfFile];
     NSString* inputStrings = [[[NSString alloc] initWithData:inputData encoding:NSUTF8StringEncoding] stringByTrimmingCharactersInSet: [NSCharacterSet newlineCharacterSet]];
 
     if ([inputStrings length] == 0 && !AllowEmptyInput)

--- a/SDAppDelegate.m
+++ b/SDAppDelegate.m
@@ -22,6 +22,7 @@ static BOOL VisualizeWhitespaceCharacters;
 static BOOL AllowEmptyInput;
 static BOOL MatchFromBeginning;
 static BOOL ScoreFirstMatchedPosition;
+static BOOL AutoSelectSingleChoice;
 
 static NSString* LastQueryString;
 static int LastCursorPos;
@@ -584,6 +585,13 @@ static NSString* ScriptAtList;
     // push choice back to start
     self.choice = 0;
     [self reflectChoice];
+
+    // if there's only one choice, and AutoSelectSingleChoice is enabled, pick
+    // this choice and exit the app
+    if (AutoSelectSingleChoice && [self.filteredSortedChoices count] == 1) {
+        self.choice = 0;
+        [self choose];
+    }
 }
 
 /******************************************************************************/
@@ -843,6 +851,7 @@ static void usage(const char* name) {
     printf(" -o           given a query, outputs results to standard output\n");
     printf(" -z           search matches symbols from beginning (instead of from end by weird default)\n");
     printf(" -a           rank early matches higher\n");
+    printf(" -1           if there's only one element, select it automatically\n");
     exit(0);
 }
 
@@ -876,13 +885,14 @@ int main(int argc, const char * argv[]) {
         SDNumRows = 10;
         SDReturnStringOnMismatch = NO;
         SDPercentWidth = -1;
+        AutoSelectSingleChoice = NO;
 
         static SDAppDelegate* delegate;
         delegate = [[SDAppDelegate alloc] init];
         [NSApp setDelegate: delegate];
 
         int ch;
-        while ((ch = getopt(argc, (char**)argv, "lvyezaf:s:r:c:b:n:w:p:q:r:t:x:o:hium")) != -1) {
+        while ((ch = getopt(argc, (char**)argv, "lvyezaf:s:r:c:b:n:w:p:q:r:t:x:o:hium1")) != -1) {
             switch (ch) {
                 case 'i': SDReturnsIndex = YES; break;
                 case 'f': queryFontName = optarg; break;
@@ -904,6 +914,7 @@ int main(int argc, const char * argv[]) {
                 case 'z': MatchFromBeginning = YES; break;
                 case 'a': ScoreFirstMatchedPosition = YES; break;
                 case 'o': queryStdout(delegate, optarg); break;
+                case '1': AutoSelectSingleChoice = YES; break;
                 case '?':
                 case 'h':
                 default:

--- a/SDAppDelegate.m
+++ b/SDAppDelegate.m
@@ -327,6 +327,11 @@ static NSString* ScriptAtList;
     }
 }
 
+
+- (void) setCursorAtEndOfQueryField {
+    [[self.queryField currentEditor] setSelectedRange: NSMakeRange(self.queryField.stringValue.length, 0)];
+}
+
 - (void) setupQueryField:(NSRect)textRect {
     NSRect iconRect, space;
     NSDivideRect(textRect, &iconRect, &textRect, NSHeight(textRect) / 1.25, NSMinXEdge);
@@ -357,6 +362,10 @@ static NSString* ScriptAtList;
     [self.queryField setAction: @selector(choose:)];
     [[self.queryField cell] setSendsActionOnEndEditing: NO];
     [[self.window contentView] addSubview: self.queryField];
+
+    // schedule to set cursor position after a delay, after the main run loop
+    // has completed its initial cycle
+    [self performSelector:@selector(setCursorAtEndOfQueryField) withObject:nil afterDelay:0.0];
 }
 
 - (void) getFrameForWindow:(NSRect*)winRect queryField:(NSRect*)textRect divider:(NSRect*)dividerRect tableView:(NSRect*)listRect {

--- a/SDAppDelegate.m
+++ b/SDAppDelegate.m
@@ -24,6 +24,7 @@ static BOOL MatchFromBeginning;
 static BOOL ScoreFirstMatchedPosition;
 static BOOL AutoSelectSingleChoice;
 static BOOL MatchWords;
+static BOOL SortMatches;
 
 static NSString* LastQueryString;
 static int LastCursorPos;
@@ -234,6 +235,9 @@ static NSString* ScriptAtList;
     // update score
 
     self.score = 0;
+
+    if (!SortMatches)
+        return;
 
     if ([self.indexSet count] == 0)
         return;
@@ -601,11 +605,13 @@ static NSString* ScriptAtList;
         }
 
         // sort remainder
-        [self.filteredSortedChoices sortUsingComparator:^NSComparisonResult(SDChoice* a, SDChoice* b) {
-            if (a.score > b.score) return NSOrderedAscending;
-            if (a.score < b.score) return NSOrderedDescending;
-            return NSOrderedSame;
-        }];
+        if (SortMatches) {
+            [self.filteredSortedChoices sortUsingComparator:^NSComparisonResult(SDChoice* a, SDChoice* b) {
+                if (a.score > b.score) return NSOrderedAscending;
+                if (a.score < b.score) return NSOrderedDescending;
+                return NSOrderedSame;
+            }];
+        }
 
     }
 }
@@ -897,6 +903,7 @@ static void usage(const char* name) {
     printf(" -a           rank early matches higher\n");
     printf(" -1           if there's only one element, select it automatically\n");
     printf(" -W           match words (rather than characters) from the query field\n");
+    printf(" -S           do not sort matches (ie, present them in the same order they appeared in the input)\n");
     exit(0);
 }
 
@@ -932,13 +939,14 @@ int main(int argc, const char * argv[]) {
         SDPercentWidth = -1;
         AutoSelectSingleChoice = NO;
         MatchWords = NO;
+        SortMatches = YES;
 
         static SDAppDelegate* delegate;
         delegate = [[SDAppDelegate alloc] init];
         [NSApp setDelegate: delegate];
 
         int ch;
-        while ((ch = getopt(argc, (char**)argv, "lvyezaf:s:r:c:b:n:w:p:q:r:t:x:o:hium1W")) != -1) {
+        while ((ch = getopt(argc, (char**)argv, "lvyezaf:s:r:c:b:n:w:p:q:r:t:x:o:hium1WS")) != -1) {
             switch (ch) {
                 case 'i': SDReturnsIndex = YES; break;
                 case 'f': queryFontName = optarg; break;
@@ -962,6 +970,7 @@ int main(int argc, const char * argv[]) {
                 case 'o': queryStdout(delegate, optarg); break;
                 case '1': AutoSelectSingleChoice = YES; break;
                 case 'W': MatchWords = YES; break;
+                case 'S': SortMatches = NO; break;
                 case '?':
                 case 'h':
                 default:

--- a/SDAppDelegate.m
+++ b/SDAppDelegate.m
@@ -790,7 +790,7 @@ static NSString* Script(NSString* pathToScript, NSString* queryInput, NSString* 
 
     NSFileHandle* stdinHandle = [NSFileHandle fileHandleWithStandardInput];
     NSData* inputData = [stdinHandle readDataToEndOfFile];
-    NSString* inputStrings = [[[NSString alloc] initWithData:inputData encoding:NSUTF8StringEncoding] stringByTrimmingCharactersInSet: [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    NSString* inputStrings = [[[NSString alloc] initWithData:inputData encoding:NSUTF8StringEncoding] stringByTrimmingCharactersInSet: [NSCharacterSet newlineCharacterSet]];
 
     if ([inputStrings length] == 0 && !AllowEmptyInput)
         return nil;


### PR DESCRIPTION
I've added a few features that are useful to my own workflow while calling `choose` from scripts. Hence this pull request.

1. _Case-sensitive and Smart-case matching._ I've added a command-line switch (`-C`) that now lets `choose` match rows against the query case-sensitively and also "smartly".

    Specifically, `-C i` is the (default) case-insensitive behavior. `-C I` means case-sensitive matching. And `-C s` means smart-case matching -- ie, case-insensitive if the query is all-lowercase, but case-sensitive if the query contains even 1 uppercase character.

    This feature also respects the `MatchFromBeginning` option (`-z`).

2. _Match whole words instead of characters._ The command-line switch `-W` now asks `choose` to match whole words (ie, contiguous characters) instead of individual characters.

    For example, _without_ this option enabled, the query `se` will match both `Seattle` and `Singapore`. But _with_ this option, it will only match `Seattle`.

    This feature also respects the `MatchFromBeginning` option (`-z`).

3. _`-S` now means "skip scoring/sorting options"._ That is, list matching options in whatever order they appeared in the input.

4. _Auto-select single choice._ I added the command-line switch `-1`, which means: If at any time there's only one choice left (either at the start, or after the user types in a few query characters), select that choice immediately instead of waiting for the user to hit Enter.

5. _Allow first choice to contain leading spaces._ I noticed that when the first choice contains leading spaces, `choose` would strip them out. But it wouldn't do this for any subsequent choice. I fixed this behavior.

6. _Append to initial query instead of replacing it._ When an initial query is provided, I noticed that it's already selected when `choose` pops up. So, whatever the user types subsequently ends up replacing the initial query rather than appending to it. I fixed this.

